### PR TITLE
Allow zipping the files in the root of the zip file

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ var shpwrite = require('shp-write');
 
 // (optional) set names for feature types and zipped folder
 var options = {
-    folder: 'myshapes',
+    folder: 'myshapes', // null means root (null is not undefined!!!)
     types: {
         point: 'mypoints',
         polygon: 'mypolygons',

--- a/src/zip.js
+++ b/src/zip.js
@@ -6,7 +6,9 @@ var write = require('./write'),
 module.exports = function(gj, options, stream = false) {
 
     var zip = new JSZip(),
-        layers = zip.folder(options && options.folder ? options.folder : 'layers');
+        layers = options && options.folder === null
+          ? zip
+          : zip.folder(options && options.folder ? options.folder : 'layers');
 
     [geojson.point(gj), geojson.line(gj), geojson.polygon(gj), geojson.multipolygon(gj), geojson.multiline(gj)]
         .forEach(function(l) {
@@ -19,7 +21,7 @@ module.exports = function(gj, options, stream = false) {
                 // geometries
                 l.geometries,
                 function(err, files) {
-                    var fileName = options && options.types[l.type.toLowerCase()] ? options.types[l.type.toLowerCase()] : l.type;
+                    var fileName = options && options.types && options.types[l.type.toLowerCase()] ? options.types[l.type.toLowerCase()] : l.type;
                     layers.file(fileName + '.shp', files.shp.buffer, { binary: true });
                     layers.file(fileName + '.shx', files.shx.buffer, { binary: true });
                     layers.file(fileName + '.dbf', files.dbf.buffer, { binary: true });


### PR DESCRIPTION
Hello, this is particularly useful for me. I decided to implement it in your repo since the upstream seems a bit outdated and I need the multipolygon too.

If you put ``{ ..., folder: null }`` in the options of ``zip()`` it will zip the files in the root directory, so you can just drag it into QGis and other GIS software (I'm beginner on that, so hope I'm not doing smth wrong)

No breaking changes

thx